### PR TITLE
Remove unused React import from SettingsPage component

### DIFF
--- a/src/renderer/src/pages/SettingsPage.tsx
+++ b/src/renderer/src/pages/SettingsPage.tsx
@@ -1,5 +1,4 @@
 import { Title } from '@mantine/core'
-import React from 'react'
 
 const SettingsPage = () => {
   return (


### PR DESCRIPTION
This pull request includes a small change to the `SettingsPage.tsx` file. The change removes an unnecessary import of `React` from the file.

* [`src/renderer/src/pages/SettingsPage.tsx`](diffhunk://#diff-d2d227fdf8c9774876dfe80a566a39fe02e85021a57c90bb97fe543063b297b3L2): Removed the unused import of `React`.